### PR TITLE
자동 배포 과정에서 빌드 중 Node.js 환경 설치 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.11.1'
+
       # Bun 설치 및 관련 환경 변수 설정
       - name: Setup Bun
         run: |


### PR DESCRIPTION
런타임 환경은 Bun이지만 pm2가 내부적으로 node.js에 대해 의존하는 것 같습니다. 빌드 과정에 node.js를 추가합니다.